### PR TITLE
Prefer Bash built-in way of changing to the script's directory

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -3,7 +3,8 @@
 # Simple CLI wrapper that discovers scripts in the commands/ directory
 
 # Cd to the directory of this script, so it can be run from anywhere
-cd "$(dirname "$(realpath "$0")")" || exit 1
+realpath="$(realpath "$0")"
+cd "${realpath%/*}"
 
 ####################
 # Helper functions #

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Cd to the directory of this script
-cd "$(dirname "$0")" || exit 1
+cd "${0%/*}"
 
 # Test variables
 TEST_CMD="test-$(( RANDOM % 900000 + 100000 ))"


### PR DESCRIPTION
Rather than calling `dirname` we can use a Bash built-in sub-string method.